### PR TITLE
Refactor Logging Calls

### DIFF
--- a/Ridgeside SMAPI Component/RidgesideVillage/CustomCPTokens.cs
+++ b/Ridgeside SMAPI Component/RidgesideVillage/CustomCPTokens.cs
@@ -11,7 +11,6 @@ namespace RidgesideVillage
         {
         private readonly IModHelper Helper;
         private readonly IManifest ModManifest;
-        private readonly IMonitor Monitor;
 
         private ModConfig Config {
             get => ModEntry.Config;
@@ -21,13 +20,12 @@ namespace RidgesideVillage
         public CustomCPTokens(IMod mod) {
             Helper = mod.Helper;
             ModManifest = mod.ModManifest;
-            Monitor = mod.Monitor;
             }
 
         public void RegisterTokens() {
             var cp = Helper.ModRegistry.GetApi<IContentPatcherApi>("Pathoschild.ContentPatcher");
             if (cp is null) {
-                Monitor.Log("Content Patcher is not installed- RSV requires CP to run. Please install CP and restart your game.", LogLevel.Alert);
+                Log.Alert("Content Patcher is not installed- RSV requires CP to run. Please install CP and restart your game.");
                 return;
                 }
 

--- a/Ridgeside SMAPI Component/RidgesideVillage/ModEntry.cs
+++ b/Ridgeside SMAPI Component/RidgesideVillage/ModEntry.cs
@@ -38,7 +38,7 @@ namespace RidgesideVillage
 
             if (!Helper.ModRegistry.IsLoaded("spacechase0.JsonAssets"))
             {
-                Monitor.Log("JSON Assets is not loaded! This mod *requires* JSON Assets!", LogLevel.Error);
+                Log.Error("JSON Assets is not loaded! This mod *requires* JSON Assets!");
                 return;
             }
             Patcher.PerformPatching();
@@ -58,7 +58,7 @@ namespace RidgesideVillage
             }
             catch (Exception e)
             {
-                Monitor.Log($"Failed to load config settings. Will use default settings instead. Error: {e}", LogLevel.Debug);
+                Log.Debug($"Failed to load config settings. Will use default settings instead. Error: {e}");
                 Config = new ModConfig();
             }
         }

--- a/Ridgeside SMAPI Component/RidgesideVillage/Patcher.cs
+++ b/Ridgeside SMAPI Component/RidgesideVillage/Patcher.cs
@@ -19,13 +19,11 @@ namespace RidgesideVillage
 
         static IModHelper Helper;
         static IManifest Manifest;
-        static IMonitor ModMonitor;
         static IJsonAssetsApi JsonAssetsAPI;
 
         public Patcher(IMod mod) {
             Helper = mod.Helper;
             Manifest = mod.ModManifest;
-            ModMonitor = mod.Monitor;
             }
 
         public void PerformPatching() {
@@ -44,7 +42,7 @@ namespace RidgesideVillage
                     return;
                     }
                 string nameToUse = locationName ?? __instance.Name;
-                ModMonitor.Log($"Player {who.Name} using magic bait at {nameToUse} with original fish result is {__result.Name}", LogLevel.Trace);
+                Log.Trace($"Player {who.Name} using magic bait at {nameToUse} with original fish result is {__result.Name}");
 
                 double catchChance =
                     (who.CurrentTool is StardewValley.Tools.FishingRod rod && rod.getBobberAttachmentIndex() == CURIOSITY_LURE)
@@ -79,18 +77,18 @@ namespace RidgesideVillage
                     int fish_id = JsonAssetsAPI.GetObjectId(fish);
                     // Currently this gives each fish a 20% chance to be caught, could be lower if we add more configuration
                     if (fish_id != -1 && !who.fishCaught.ContainsKey(fish_id) && who.FishingLevel >= MIN_FISHING && Game1.random.NextDouble() < catchChance) {
-                        ModMonitor.Log($"Fish {fish} (ID: {fish_id}) is caught: {who.fishCaught.ContainsKey(fish_id)}, setting fish result to this fish", LogLevel.Trace);
+                        Log.Trace($"Fish {fish} (ID: {fish_id}) is caught: {who.fishCaught.ContainsKey(fish_id)}, setting fish result to this fish");
                         __result = new StardewValley.Object(fish_id, 1);
                         return;
                         }
                     else {
-                        ModMonitor.Log($"Fish {fish} (ID: {fish_id}) is caught: {who.fishCaught.ContainsKey(fish_id)}", LogLevel.Trace);
+                        Log.Trace($"Fish {fish} (ID: {fish_id}) is caught: {who.fishCaught.ContainsKey(fish_id)}");
                         }
                     }
                 return;
                 }
             catch (Exception ex) {
-                ModMonitor.Log($"Failed in {nameof(GetFish_Postfix)}:\n{ex}", LogLevel.Error);
+                Log.Error($"Failed in {nameof(GetFish_Postfix)}:\n{ex}");
                 }
             }
 

--- a/Ridgeside SMAPI Component/RidgesideVillage/RidgesideVillage.csproj
+++ b/Ridgeside SMAPI Component/RidgesideVillage/RidgesideVillage.csproj
@@ -54,6 +54,7 @@
     <Compile Include="ModEntry.cs" />
     <Compile Include="Patcher.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />

--- a/Ridgeside SMAPI Component/RidgesideVillage/Utils.cs
+++ b/Ridgeside SMAPI Component/RidgesideVillage/Utils.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RidgesideVillage
+    {
+    internal static class Log
+        {
+        internal static void Error(string msg) => ModEntry.ModMonitor.Log(msg, StardewModdingAPI.LogLevel.Error);
+        internal static void Alert(string msg) => ModEntry.ModMonitor.Log(msg, StardewModdingAPI.LogLevel.Alert);
+        internal static void Warn(string msg) => ModEntry.ModMonitor.Log(msg, StardewModdingAPI.LogLevel.Warn);
+        internal static void Info(string msg) => ModEntry.ModMonitor.Log(msg, StardewModdingAPI.LogLevel.Info);
+        internal static void Debug(string msg) => ModEntry.ModMonitor.Log(msg, StardewModdingAPI.LogLevel.Debug);
+        internal static void Trace(string msg) => ModEntry.ModMonitor.Log(msg, StardewModdingAPI.LogLevel.Trace);
+
+        }
+    }


### PR DESCRIPTION
We shouldn't be passing the singleton `ModEntry.Monitor` around, especially if it has been recorded as a `static` in the `ModEntry` class.

Also, invoking `Monitor.Log` is fraught with the mistake of forgetting to append the proper `LogLevel` at end; let's prevent that from happening.
